### PR TITLE
Move ejected core files to project root

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -87,7 +87,7 @@ func Build() {
 	fmt.Printf("Prepping client SPA data took %s\n", elapsed)
 
 	start = time.Now()
-	svelteBuild := exec.Command("node", "layout/ejected/build.js", clientBuildStr, staticBuildStr, allNodesStr)
+	svelteBuild := exec.Command("node", "ejected/build.js", clientBuildStr, staticBuildStr, allNodesStr)
 	svelteBuild.Stdout = os.Stdout
 	svelteBuild.Stderr = os.Stderr
 	svelteBuild.Run()

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -74,6 +74,8 @@ func Build() {
 
 	tempFiles := build.EjectTemp()
 
+	build.EjectCopy(buildPath)
+
 	start := time.Now()
 	// Build JSON from "content/" directory.
 	staticBuildStr, allNodesStr := build.DataSource(buildPath, siteConfig)

--- a/cmd/build/eject_clean.go
+++ b/cmd/build/eject_clean.go
@@ -20,7 +20,7 @@ func EjectClean(tempFiles []string) {
 	// If no files were ejected by user, clean up the directory after build.
 	if len(tempFiles) == len(generated.Ejected) {
 		fmt.Println("Removing the ejected directory.")
-		os.Remove("layout/ejected")
+		os.Remove("ejected")
 	}
 
 	elapsed := time.Since(start)

--- a/cmd/build/eject_clean.go
+++ b/cmd/build/eject_clean.go
@@ -12,6 +12,8 @@ func EjectClean(tempFiles []string) {
 
 	start := time.Now()
 
+	fmt.Printf("\nRemoving core files that aren't ejected:\n")
+
 	for _, file := range tempFiles {
 		fmt.Printf("Removing temp file '%s'\n", file)
 		os.Remove(file)

--- a/cmd/build/eject_copy.go
+++ b/cmd/build/eject_copy.go
@@ -1,0 +1,68 @@
+package build
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// EjectCopy does a direct copy of any ejectable js files needed in spa build dir.
+func EjectCopy(buildPath string) {
+
+	start := time.Now()
+
+	fmt.Printf("\nCopying ejectable core files to their destination:\n")
+
+	copiedSourceCounter := 0
+
+	ejectedFilesErr := filepath.Walk("ejected", func(ejectPath string, ejectFileInfo os.FileInfo, err error) error {
+		// Make list of files not to copy to build.
+		excludedFiles := []string{
+			"ejected/build.js",
+		}
+		// Check if the current file is in the excluded list.
+		excluded := false
+		for _, excludedFile := range excludedFiles {
+			if excludedFile == ejectPath {
+				excluded = true
+			}
+		}
+		// If the file is already in .js format just copy it straight over to build dir.
+		if filepath.Ext(ejectPath) == ".js" && !excluded {
+
+			destPath := buildPath + "/spa/"
+			os.MkdirAll(destPath+"ejected", os.ModePerm)
+
+			from, err := os.Open(ejectPath)
+			if err != nil {
+				fmt.Printf("Could not open source .js file for copying: %s\n", err)
+			}
+			defer from.Close()
+
+			to, err := os.Create(destPath + ejectPath)
+			if err != nil {
+				fmt.Printf("Could not create destination .js file for copying: %s\n", err)
+			}
+			defer to.Close()
+
+			_, fileCopyErr := io.Copy(to, from)
+			if err != nil {
+				fmt.Printf("Could not copy .js from source to destination: %s\n", fileCopyErr)
+			}
+
+			copiedSourceCounter++
+		}
+		return nil
+	})
+	if ejectedFilesErr != nil {
+		fmt.Printf("Could not get ejectable file: %s", ejectedFilesErr)
+	}
+
+	fmt.Printf("Number of ejectable core files copied: %d\n", copiedSourceCounter)
+
+	elapsed := time.Since(start)
+	fmt.Printf("Copying ejectable core files for build took %s\n", elapsed)
+
+}

--- a/cmd/build/eject_temp.go
+++ b/cmd/build/eject_temp.go
@@ -14,6 +14,8 @@ func EjectTemp() []string {
 
 	start := time.Now()
 
+	fmt.Printf("\nEjecting core files to be used in build:\n")
+
 	ejectedPath := "ejected"
 
 	tempFiles := []string{}

--- a/cmd/build/eject_temp.go
+++ b/cmd/build/eject_temp.go
@@ -14,7 +14,7 @@ func EjectTemp() []string {
 
 	start := time.Now()
 
-	ejectedPath := "layout/ejected"
+	ejectedPath := "ejected"
 
 	tempFiles := []string{}
 

--- a/cmd/build/gopack.go
+++ b/cmd/build/gopack.go
@@ -19,7 +19,7 @@ func Gopack(buildPath string) {
 
 	gopackDir := buildPath + "/spa/web_modules"
 
-	fmt.Println("\nRunning gopack to build esm support for:")
+	fmt.Println("\nRunning gopack to build esm support for npm dependencies:")
 	// Find all the "dependencies" specified in package.json.
 	for module, version := range readers.GetNpmConfig().Dependencies {
 		fmt.Printf("- %s, version %s\n", module, version)

--- a/cmd/eject.go
+++ b/cmd/eject.go
@@ -38,7 +38,7 @@ automatically).`,
 		if len(args) < 1 && EjectAll {
 			fmt.Println("All flag used, eject all core files.")
 			for _, file := range allEjectableFiles {
-				filePath := "layout/ejected" + file
+				filePath := "ejected" + file
 				content := generated.Ejected[file]
 				ejectFile(filePath, content)
 			}
@@ -65,7 +65,7 @@ automatically).`,
 				return
 			}
 			if confirmed == "Yes" {
-				filePath := "layout/ejected" + result
+				filePath := "ejected" + result
 				content := generated.Ejected[result]
 				ejectFile(filePath, content)
 			}
@@ -84,7 +84,7 @@ automatically).`,
 					}
 				}
 				if fileExists {
-					filePath := "layout/ejected" + arg
+					filePath := "ejected" + arg
 					content := generated.Ejected[arg]
 					ejectFile(filePath, content)
 				} else {


### PR DESCRIPTION
Having the ejectable files temp writing and cleanup up in the `layout` folder that we're watching with [fsnotify](https://github.com/fsnotify/fsnotify) causes the dev server to do an infinite build loop. Related to https://github.com/plentico/plenti/issues/8

This moves the `ejected` folder to the project root where it isn't being watched for changes.