### PR TITLE
Exclude special files (starting with '.') from build process

### DIFF
--- a/cmd/build/data_source.go
+++ b/cmd/build/data_source.go
@@ -60,7 +60,7 @@ func DataSource(buildPath string, siteConfig readers.SiteConfig, tempBuildDir st
 			fileName := parts[len(parts)-1]
 
 			// Don't add _blueprint.json or other special named files starting with underscores.
-			if fileName[:1] != "_" {
+			if fileName[:1] != "_" && fileName[:1] != "." {
 
 				// Get the contents of the file.
 				fileContentBytes, readFileErr := ioutil.ReadFile(path)

--- a/cmd/build/node_data_source.go
+++ b/cmd/build/node_data_source.go
@@ -45,7 +45,7 @@ func NodeDataSource(buildPath string, siteConfig readers.SiteConfig) (string, st
 			fileName := parts[len(parts)-1]
 
 			// Don't add _blueprint.json or other special named files starting with underscores.
-			if fileName[:1] != "_" {
+			if fileName[:1] != "_" && fileName[:1] != "." {
 
 				// Get the contents of the file.
 				fileContentBytes, readFileErr := ioutil.ReadFile(path)


### PR DESCRIPTION
This prevents crashes when building from mac computers. 
Without the fix, the system tries to parse .DS_Store file as JSON which fails and corrupts the build.