### PR TITLE
Add curly brackets to file when creating new content type with single flag

### DIFF
--- a/cmd/type.go
+++ b/cmd/type.go
@@ -111,13 +111,22 @@ func singleTypeProcess(typeName string) error {
 
 	fmt.Printf("Creating new single type content source: %s\n", singleTypePath)
 
-	_, createSingleTypeErr := os.OpenFile(singleTypePath, os.O_RDONLY|os.O_CREATE, os.ModePerm)
+	f, createSingleTypeErr := os.OpenFile(singleTypePath, os.O_RDWR|os.O_CREATE, os.ModePerm)
 
 	if createSingleTypeErr != nil {
 		errorMsg := fmt.Sprintf("Can't create single type named \"%s\": %s", typeName, createSingleTypeErr)
 		fmt.Printf(errorMsg)
 		return errors.New(errorMsg)
 	}
+
+	_, err := f.Write([]byte("{}"))
+	if err != nil {
+		errorMsg := fmt.Sprintf("Can't add empty curly brackets to single type named \"%s\": %s", typeName, createSingleTypeErr)
+		fmt.Printf(errorMsg)
+		return errors.New(errorMsg)
+	}
+
+	defer f.Close()
 
 	return nil
 }


### PR DESCRIPTION
Hello Plenti team, I like your project and I'd like to start contributing to it. This PR is to prevent errors after you create a new content type with the --single flag, I create the default file with an empy JSON object.

Fix #111 

### Create a new site and content type --single 

<img width="826" alt="plenti" src="https://user-images.githubusercontent.com/17286493/104662773-1fe0b980-5691-11eb-83d6-724fe6797d15.png">

### Site running 🚀 

![demo site](https://user-images.githubusercontent.com/17286493/104662873-58809300-5691-11eb-878e-04dd183e65d2.png)
