### PR TITLE
gomod/full import paths

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"plenti/cmd/build"
-	"plenti/common"
-	"plenti/readers"
 	"time"
+
+	"github.com/plentico/plenti/cmd/build"
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/readers"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/build/assets_copy.go
+++ b/cmd/build/assets_copy.go
@@ -5,9 +5,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"plenti/common"
 	"strings"
 	"time"
+
+	"github.com/plentico/plenti/common"
 )
 
 // AssetsCopy does a direct copy of any static assets.

--- a/cmd/build/client.go
+++ b/cmd/build/client.go
@@ -5,12 +5,13 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"plenti/common"
-	"plenti/readers"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/readers"
 
 	"rogchap.com/v8go"
 )

--- a/cmd/build/data_source.go
+++ b/cmd/build/data_source.go
@@ -6,12 +6,13 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"plenti/common"
-	"plenti/readers"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/readers"
 )
 
 // Doreload and other flags should probably be part of a config accessible across build.

--- a/cmd/build/eject_clean.go
+++ b/cmd/build/eject_clean.go
@@ -2,8 +2,9 @@ package build
 
 import (
 	"os"
-	"plenti/generated"
 	"time"
+
+	"github.com/plentico/plenti/generated"
 )
 
 // EjectClean removes core files that hadn't been ejected to project filesystem.

--- a/cmd/build/eject_copy.go
+++ b/cmd/build/eject_copy.go
@@ -5,9 +5,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"plenti/common"
 	"strings"
 	"time"
+
+	"github.com/plentico/plenti/common"
 )
 
 // EjectCopy does a direct copy of any ejectable js files needed in spa build dir.

--- a/cmd/build/eject_temp.go
+++ b/cmd/build/eject_temp.go
@@ -5,9 +5,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"plenti/common"
-	"plenti/generated"
 	"time"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/generated"
 )
 
 // EjectTemp temporarily writes ejectable core files to project filesystem.

--- a/cmd/build/gopack.go
+++ b/cmd/build/gopack.go
@@ -7,11 +7,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"plenti/common"
-	"plenti/readers"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/readers"
 )
 
 // Gopack ensures ESM support for NPM dependencies.

--- a/cmd/build/node_client.go
+++ b/cmd/build/node_client.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"plenti/common"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/plentico/plenti/common"
 )
 
 // NodeClient preps the client SPA for execution via NodeJS (NOTE: This is legacy functionality).

--- a/cmd/build/node_data_source.go
+++ b/cmd/build/node_data_source.go
@@ -5,10 +5,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"plenti/readers"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/plentico/plenti/readers"
 )
 
 // NodeDataSource gathers data json from "content/" directory to use in NodeJS build (NOTE: This is legacy).

--- a/cmd/build/npm_defaults.go
+++ b/cmd/build/npm_defaults.go
@@ -5,9 +5,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"plenti/common"
-	"plenti/generated"
 	"time"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/generated"
 )
 
 // NpmDefaults creates the node_modules folder with core defaults if it doesn't already exist.

--- a/cmd/build/themes_copy.go
+++ b/cmd/build/themes_copy.go
@@ -5,11 +5,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"plenti/common"
-	"plenti/readers"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/readers"
 )
 
 // ThemesCopy copies nested themes into a temporary working directory.

--- a/cmd/build/themes_merge.go
+++ b/cmd/build/themes_merge.go
@@ -5,10 +5,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"plenti/common"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/plentico/plenti/common"
 )
 
 // ThemesMerge combines any nested themes with the current project.

--- a/cmd/eject.go
+++ b/cmd/eject.go
@@ -5,8 +5,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"plenti/common"
-	"plenti/generated"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/generated"
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"

--- a/cmd/reload.go
+++ b/cmd/reload.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"log"
-	"plenti/common"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/plentico/plenti/common"
 
 	"golang.org/x/net/websocket"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"plenti/common"
+
+	"github.com/plentico/plenti/common"
 
 	"github.com/spf13/cobra"
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -9,11 +9,11 @@ import (
 	"os"
 	"time"
 
-	"plenti/cmd/build"
+	"github.com/plentico/plenti/cmd/build"
 
-	"plenti/common"
+	"github.com/plentico/plenti/common"
 
-	"plenti/readers"
+	"github.com/plentico/plenti/readers"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/briandowns/spinner"

--- a/cmd/site.go
+++ b/cmd/site.go
@@ -7,9 +7,10 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"plenti/common"
-	"plenti/generated"
 	"strings"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/generated"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/manifoldco/promptui"

--- a/cmd/theme_add.go
+++ b/cmd/theme_add.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"plenti/common"
-	"plenti/readers"
-	"plenti/writers"
 	"strings"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/readers"
+	"github.com/plentico/plenti/writers"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"

--- a/cmd/theme_disable.go
+++ b/cmd/theme_disable.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"plenti/common"
-	"plenti/readers"
-	"plenti/writers"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/readers"
+	"github.com/plentico/plenti/writers"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/theme_enable.go
+++ b/cmd/theme_enable.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"plenti/common"
-	"plenti/readers"
-	"plenti/writers"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/readers"
+	"github.com/plentico/plenti/writers"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/theme_remove.go
+++ b/cmd/theme_remove.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"plenti/common"
-	"plenti/readers"
-	"plenti/writers"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/readers"
+	"github.com/plentico/plenti/writers"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/theme_update.go
+++ b/cmd/theme_update.go
@@ -3,7 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"plenti/readers"
+
+	"github.com/plentico/plenti/readers"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/type.go
+++ b/cmd/type.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"plenti/common"
 	"strings"
+
+	"github.com/plentico/plenti/common"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/watcher.go
+++ b/cmd/watcher.go
@@ -5,11 +5,12 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"plenti/cmd/build"
+
+	"github.com/plentico/plenti/cmd/build"
 
 	"sync"
 
-	"plenti/common"
+	"github.com/plentico/plenti/common"
 
 	"time"
 

--- a/generators/main.go
+++ b/generators/main.go
@@ -5,8 +5,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"plenti/common"
 	"strings"
+
+	"github.com/plentico/plenti/common"
 )
 
 // Packages static files in your Go binary.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module plenti
+module github.com/plentico/plenti
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 //go:generate go run generators/main.go
 
-import "plenti/cmd"
+import "github.com/plentico/plenti/cmd"
 
 func main() {
 	cmd.Execute()

--- a/writers/site_config.go
+++ b/writers/site_config.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"plenti/common"
-	"plenti/readers"
+
+	"github.com/plentico/plenti/common"
+	"github.com/plentico/plenti/readers"
 )
 
 // SetSiteConfig writes values to the site's configuration file.


### PR DESCRIPTION
Changed go mod to use github.com/plentico/plenti and adjusted import which will allow to work with go install