### PR TITLE
Fix adding page by handling hash locations in routes

### DIFF
--- a/cmd/defaults/ejected/cms/add_content.svelte
+++ b/cmd/defaults/ejected/cms/add_content.svelte
@@ -66,8 +66,7 @@
 
         // No errors, redirect to "add" page
         if (validationErrors.length === 0) {
-            history.pushState(null, '', '/');
-            location.hash = '#add/' + selectedType + '/' + filename;
+            history.pushState(null, '', '/#add/' + selectedType + '/' + filename);
             showAdd = false; 
             showEditor = true;
         }


### PR DESCRIPTION
Hash locations were previously handled seperately from routes and that caused some race condition that was seen as hash location not rendering. Now hash locations override router routes.

It now also renders 404 instead of rendering home page when trying to access invalid "add page" hash route, for example `/#add/not-type/filename` where `not-type` is not existing page type.