### PR TITLE
Added support for platform Darwin arm64 aka Apple Silicon

### DIFF
--- a/cmd/build/client.go
+++ b/cmd/build/client.go
@@ -47,22 +47,14 @@ func Client(buildPath string, coreFS embed.FS) error {
 	compilerStr := strings.Replace(string(compiler), "self.performance.now();", "'';", 1)
 	// Remove 'require' that breaks v8go on line 22647 of node_modules/svelte/compiler.js.
 	compilerStr = strings.Replace(compilerStr, "const Url$1 = (typeof URL !== 'undefined' ? URL : require('url').URL);", "", 1)
-	ctx, err := v8go.NewContext(nil)
-	if err != nil {
-		return fmt.Errorf("Could not create Isolate: %w\n", err)
-
-	}
+	ctx := v8go.NewContext(nil)
 	_, err = ctx.RunScript(compilerStr, "compile_svelte")
 	if err != nil {
 		return fmt.Errorf("Could not add svelte compiler: %w\n", err)
 
 	}
 
-	SSRctx, err = v8go.NewContext(nil)
-	if err != nil {
-		return fmt.Errorf("Could not create Isolate: %w\n", err)
-
-	}
+	SSRctx = v8go.NewContext(nil)
 	// Fix "ReferenceError: exports is not defined" errors on line 1319 (exports.current_component;).
 	if _, err := SSRctx.RunScript("var exports = {};", "create_ssr"); err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/plentico/plenti
 
-go 1.18
+go 1.20
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/tdewolff/minify/v2 v2.11.7
 	golang.org/x/net v0.7.0
-	rogchap.com/v8go v0.5.1
+	rogchap.com/v8go v0.8.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -417,6 +417,6 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-rogchap.com/v8go v0.5.1 h1:yx7uQC2ezAHthCHLHl4NuH3eprVLBtNl6Utm/ELjZ+w=
-rogchap.com/v8go v0.5.1/go.mod h1:IitZnaOtWSJadY/7qinKHIEHpxsilMWyLQ+Efdo4n4I=
+rogchap.com/v8go v0.8.0 h1:/crDEiga68kOtbIqw3K9Rt9OztYz0LhAPHm2e3wK7Q4=
+rogchap.com/v8go v0.8.0/go.mod h1:MxgP3pL2MW4dpme/72QRs8sgNMmM0pRc8DPhcuLWPAs=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=


### PR DESCRIPTION
This pull request adds support to build and run Plenti on the Darwin arm64 platform, also know as Apple Silicon/M1/M2, etc.