### PR TITLE
Enhacement: Check Port Availability

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -42,14 +42,14 @@ var LocalFlag bool
 
 func checkPortAvailability(port int) bool {
 	address := fmt.Sprintf("localhost:%d", port)
-	listener, err := net.Listen("tcp", address)
+	conn, err := net.Dial("tcp", address)
 
-	if err == nil {
-		return false // Port is already in use
+	if err != nil {
+		return true // Port is available
 	}
-	defer listener.Close()
+	defer conn.Close()
 
-	return true // Port is available
+	return false // Port is already in use
 }
 
 func setPort(siteConfig readers.SiteConfig) int {


### PR DESCRIPTION
Hello there! 
I'm submiting this pull request to address the issue #275 . The current behavior leads to a complete build process even if the specified port is already in use, resulting in an error message afterward. Now, before starting the build process for serving the site, it checks if the specified port is available. If the port is already occupied, it immediately displays an error message, guiding users to either override the port using the `-p` flag or update the port in the Plenti configuration file. 
I've tested these changes to ensure they work okay. 
Any feedback is greatly appreciated. Thank you for your time and consideration! 😊

Fixes #275