### PR TITLE
Fix html sanitizer paste feature to fallback on plain text format

### DIFF
--- a/defaults/core/cms/html_sanitizer.svelte
+++ b/defaults/core/cms/html_sanitizer.svelte
@@ -8,11 +8,9 @@
 	// https://developer.mozilla.org/en-US/docs/Web/API/Element/paste_event
 	export const plaintextPaste = e => {
 		e.preventDefault();
-		const rawHtmlPaste = (e.clipboardData || window.clipboardData).getData("text/html");
-		if (rawHtmlPaste === "") {
-			return;
-		}
-		const paste = HtmlSanitizer.SanitizeHtml(rawHtmlPaste);
+		const data = e.clipboardData || window.clipboardData;
+		const raw = data.getData("text/html") || data.getData("text");
+		const paste = HtmlSanitizer.SanitizeHtml(raw);
 		document.execCommand("insertHTML", false, paste);
 	}
 	


### PR DESCRIPTION
Fixes issue with html sanitizer paste feature not working if the clipboard content was not copied from an html source