### PR TITLE
expand env vars to include an array of user defined sitevars. Inject …

### DIFF
--- a/readers/site_config.go
+++ b/readers/site_config.go
@@ -25,6 +25,7 @@ type SiteConfig struct {
 		Port int `json:"port"`
 	} `json:"local"`
 	Routes map[string]string `json:"routes"`
+	SiteVars map[string]interface{} `json:"sitevars"`
 	CMS    struct {
 		Provider    string `json:"provider"`
 		Repo        string `json:"repo"`


### PR DESCRIPTION
…env  into  all pages of the  published plenti/svelte site.

Injecting the env vars into window.dev makes referencing env vars in svelte layouts/components etc without having to add env as a prop in multiple locations, NOTE. using this version of plenti breaks all projects that use the current version. To build the themes (https://plenti.co/themes) I had to remove references to env.

Maybe I need a lesson in passing props to svelte compnents. I built another version of the plenti-sitevars that doesn't inject the env into windows.env but I could not work out where, in the hierachy of components I needed to pass env as a prop so when I wanted to use env.sitevars in a layout things started getting env prop soupy.

Interested to here your thoughts @jimafisk 