### PR TITLE
Support independent CMS authorization, token, and API endpoint overrides

### DIFF
--- a/cmd/build/data_source.go
+++ b/cmd/build/data_source.go
@@ -75,6 +75,10 @@ type cms struct {
 	redirectUrl string
 	appId       string
 	branch      string
+	// Optional endpoint overrides (empty = derive from repo, as before).
+	authorizationUrl string
+	accessTokenUrl   string
+	apiBaseUrl       string
 }
 
 // DataSource builds json list from "content/" directory.
@@ -105,11 +109,14 @@ func DataSource(buildPath string, spaPath string, siteConfig readers.SiteConfig)
 		entrypointJS:   siteConfig.EntryPointJS,
 		sitevars:       string(sitevarsJSON),
 		cms: cms{
-			provider:    siteConfig.CMS.Provider,
-			repo:        siteConfig.CMS.Repo,
-			redirectUrl: siteConfig.CMS.RedirectUrl,
-			appId:       siteConfig.CMS.AppId,
-			branch:      siteConfig.CMS.Branch,
+			provider:         siteConfig.CMS.Provider,
+			repo:             siteConfig.CMS.Repo,
+			redirectUrl:      siteConfig.CMS.RedirectUrl,
+			appId:            siteConfig.CMS.AppId,
+			branch:           siteConfig.CMS.Branch,
+			authorizationUrl: siteConfig.CMS.AuthorizationUrl,
+			accessTokenUrl:   siteConfig.CMS.AccessTokenUrl,
+			apiBaseUrl:       siteConfig.CMS.ApiBaseUrl,
 		},
 	}
 
@@ -137,6 +144,9 @@ func DataSource(buildPath string, spaPath string, siteConfig readers.SiteConfig)
 		"', redirectUrl: '" + env.cms.redirectUrl +
 		"', appId: '" + env.cms.appId +
 		"', branch: '" + env.cms.branch +
+		"', authorizationUrl: '" + env.cms.authorizationUrl +
+		"', accessTokenUrl: '" + env.cms.accessTokenUrl +
+		"', apiBaseUrl: '" + env.cms.apiBaseUrl +
 		"' } };"
 
 	// Start the new content.js file.

--- a/defaults/core/cms/ENDPOINT-OVERRIDES.md
+++ b/defaults/core/cms/ENDPOINT-OVERRIDES.md
@@ -1,0 +1,69 @@
+# CMS endpoint overrides
+
+By default Plenti's Git-CMS derives three browser-facing endpoints from a single origin —
+the `repo` URL in `plenti.json`:
+
+| Endpoint | Default (derived from `repo`) |
+|---|---|
+| OAuth authorization | `<repo-origin>` + provider path (`/login/oauth/authorize` for Gitea/Forgejo, `/oauth/authorize` for GitLab) |
+| OAuth token exchange | `<repo-origin>` + provider path (`/login/oauth/access_token` · `/oauth/token`) |
+| Provider API base | `<repo-origin>/api/v1` (Gitea/Forgejo) · `<repo-origin>/api/v4` (GitLab) |
+
+This is correct for the common case where the browser reaches the git host directly at one
+origin. Some self-hosted / reverse-proxied deployments need these to differ — for example, to
+route the **token exchange** and **repository API** through a **same-origin proxy** on the site's
+own domain (avoiding CORS) while keeping **OAuth authorization** a top-level navigation to the git
+host's canonical origin (so the git host serves its own login/consent UI and its `ROOT_URL` stays
+truthful).
+
+## Optional fields
+
+Add any of these to the `cms` block in `plenti.json`. **Each is independent, and each is optional —
+when omitted (or empty), the endpoint is derived from `repo` exactly as before, so existing sites
+are unaffected.**
+
+| Field | Overrides | Falls back to (when absent) |
+|---|---|---|
+| `authorization_url` | the full OAuth authorize URL | `<repo-origin>` + provider authorize path |
+| `access_token_url` | the full OAuth token URL (used for **both** the code exchange **and** token refresh) | `<repo-origin>` + provider token path |
+| `api_base_url` | the provider API base URL | `<repo-origin>/api/v1` or `/api/v4` |
+
+The OAuth flow is unchanged: still a public PKCE client (no client secret), with `state`,
+`code_challenge`, `code_challenge_method=S256`, and `code_verifier` exactly as before — only the
+endpoint *resolution* changes.
+
+## Example — split origin (token + API proxied, authorize canonical)
+
+```json
+{
+  "cms": {
+    "provider": "gitea",
+    "repo": "https://git.example.com/owner/repository",
+    "branch": "main",
+    "redirect_url": "https://site.example.com",
+    "app_id": "public-oauth-client-id",
+
+    "authorization_url": "https://git.example.com/login/oauth/authorize",
+    "access_token_url": "https://site.example.com/_cms/git/login/oauth/access_token",
+    "api_base_url": "https://site.example.com/_cms/git/api/v1"
+  }
+}
+```
+
+With this config the browser:
+
+- navigates to **`git.example.com`** for authorization (the git host shows its own login/consent);
+- exchanges the code and refreshes tokens via **`site.example.com/_cms/git/...`** (same-origin);
+- makes repository API calls via **`site.example.com/_cms/git/api/v1`** (same-origin).
+
+Routing `site.example.com/_cms/git/*` → the git host is configured on the site's own web server /
+edge (Caddy `reverse_proxy`, Nginx `proxy_pass`, a Netlify/Vercel function, or a Cloudflare
+Worker). **That proxy is deployment-specific and lives outside Plenti** — Plenti only needs to be
+told which URLs to call. Platforms without a configurable proxy layer (e.g. GitHub Pages, GitLab
+Pages) can't use the split; they simply omit these fields and get the default single-origin
+behaviour.
+
+## Backward compatibility
+
+Omitting all three fields reproduces the current behaviour exactly. The defaults are unchanged for
+GitLab, Gitea, and Forgejo (Forgejo resolves identically to Gitea).

--- a/defaults/core/cms/auth.js
+++ b/defaults/core/cms/auth.js
@@ -19,10 +19,22 @@ if (provider === "gitea" || provider === "forgejo") {
     access_token_endpoint = "/login/oauth/access_token";
 }
 
+// Optional endpoint overrides (env.cms.authorizationUrl / accessTokenUrl). When an
+// override is absent (empty string), fall back to the original derivation —
+// repoUrl.origin + the provider's default path — so existing sites are unchanged.
+// This lets the OAuth token exchange be routed through a same-origin proxy (e.g. when
+// the editor runs on a custom domain) while OAuth authorization can stay a top-level
+// navigation to the git host's canonical origin.
+const authorizationUrl = env.cms.authorizationUrl || repoUrl.origin + authorization_endpoint;
+const accessTokenUrl = env.cms.accessTokenUrl || repoUrl.origin + access_token_endpoint;
+
 const settings = {
     provider: provider,
     authorization_endpoint: authorization_endpoint,
     access_token_endpoint: access_token_endpoint,
+    // Fully-resolved, override-aware endpoint URLs (used in place of `server + endpoint`).
+    authorizationUrl: authorizationUrl,
+    accessTokenUrl: accessTokenUrl,
     server: repoUrl.origin,
     group: repoUrl.pathname.split('/')[1],
     repository: repoUrl.pathname.split('/')[2],
@@ -123,21 +135,21 @@ const requestAuthCode = async () => {
     codeVerifierStore.set(generateString());
     const codeChallenge = await hash(codeVerifier);
 
-    const { authorization_endpoint, server, redirectUrl, appId } = settings;
-    window.location.href = server + authorization_endpoint
-        + "?client_id=" + encodeURIComponent(appId) 
+    const { authorizationUrl, redirectUrl, appId } = settings;
+    window.location.href = authorizationUrl
+        + "?client_id=" + encodeURIComponent(appId)
         + "&redirect_uri=" + encodeURIComponent(redirectUrl)
         + "&response_type=code"
-        + "&state=" + encodeURIComponent(state) 
-        + "&code_challenge=" + encodeURIComponent(codeChallenge) 
+        + "&state=" + encodeURIComponent(state)
+        + "&code_challenge=" + encodeURIComponent(codeChallenge)
         + "&code_challenge_method=S256";
 };
 
 const requestAccessToken = async code => {
-    const { access_token_endpoint, server, redirectUrl, appId } = settings;
-    const response = await fetch(server + access_token_endpoint
-        + "?client_id=" + encodeURIComponent(appId) 
-        + "&code=" + encodeURIComponent(code) 
+    const { accessTokenUrl, redirectUrl, appId } = settings;
+    const response = await fetch(accessTokenUrl
+        + "?client_id=" + encodeURIComponent(appId)
+        + "&code=" + encodeURIComponent(code)
         + "&grant_type=authorization_code"
         + "&redirect_uri=" + encodeURIComponent(redirectUrl)
         + "&code_verifier=" + encodeURIComponent(codeVerifier),
@@ -156,11 +168,13 @@ const requestAccessToken = async code => {
 };
 
 const requestRefreshToken = async () => {
-    const { access_token_endpoint, server, redirectUrl, appId } = settings;
+    const { accessTokenUrl, redirectUrl, appId } = settings;
     if (!codeVerifier) {
         throw new Error("Code verifier not saved to session storage");
     }
-    const response = await fetch(server + access_token_endpoint 
+    // Same override-aware token endpoint as the initial code exchange, so a proxied
+    // token URL applies to refresh too (otherwise refresh would go cross-origin).
+    const response = await fetch(accessTokenUrl
         + "?client_id=" + encodeURIComponent(appId)
         + "&refresh_token=" + encodeURIComponent(tokens.refresh_token)
         + "&grant_type=refresh_token"

--- a/defaults/core/cms/providers/gitea.js
+++ b/defaults/core/cms/providers/gitea.js
@@ -5,7 +5,10 @@ import evaluateRoute from '../route_eval.js';
 const repoUrl = makeUrl(env.cms.repo);
 const owner = repoUrl.pathname.split('/')[1];
 const repo = repoUrl.pathname.split('/')[2];
-const apiBaseUrl = `${repoUrl.origin}/api/v1`;
+// Optional override (env.cms.apiBaseUrl). Empty falls back to the original derivation
+// (repoUrl.origin + /api/v1), so existing sites are unchanged; set it to route the
+// repository API through a same-origin proxy.
+const apiBaseUrl = env.cms.apiBaseUrl || `${repoUrl.origin}/api/v1`;
 
 const capitalizeFirstLetter = string => {
   return string.charAt(0).toUpperCase() + string.slice(1);

--- a/defaults/core/cms/providers/gitlab.js
+++ b/defaults/core/cms/providers/gitlab.js
@@ -3,7 +3,10 @@ import { makeUrl, normalizeRoute } from '../url_checker.js';
 import evaluateRoute from '../route_eval.js';
 
 const repoUrl = makeUrl(env.cms.repo);
-const apiBaseUrl = `${repoUrl.origin}/api/v4`;
+// Optional override (env.cms.apiBaseUrl). Empty falls back to the original derivation
+// (repoUrl.origin + /api/v4), so existing sites are unchanged; set it to route the
+// repository API through a same-origin proxy.
+const apiBaseUrl = env.cms.apiBaseUrl || `${repoUrl.origin}/api/v4`;
 
 const capitalizeFirstLetter = string => {
   return string.charAt(0).toUpperCase() + string.slice(1);

--- a/readers/site_config.go
+++ b/readers/site_config.go
@@ -32,6 +32,14 @@ type SiteConfig struct {
 		RedirectUrl string `json:"redirect_url"`
 		AppId       string `json:"app_id"`
 		Branch      string `json:"branch"`
+		// Optional endpoint overrides. When empty, each endpoint is derived from
+		// "repo" exactly as before (origin + the provider's default path), so existing
+		// sites are unaffected. Set these to route OAuth token exchange and/or the
+		// provider API through a same-origin proxy while OAuth authorization stays a
+		// top-level navigation to the git host's canonical origin.
+		AuthorizationUrl string `json:"authorization_url"`
+		AccessTokenUrl   string `json:"access_token_url"`
+		ApiBaseUrl       string `json:"api_base_url"`
 	} `json:"cms"`
 }
 


### PR DESCRIPTION
## Summary

Plenti's Git-backed CMS currently derives three browser-facing endpoints from the origin of the `repo` URL in `plenti.json`:

* the OAuth **authorization** endpoint;
* the OAuth **access-token** endpoint; and
* the **provider API** base URL.

This is appropriate when the browser reaches the Git provider directly through a single origin. Some self-hosted and reverse-proxied deployments, however, need these requests to use different public endpoints.

For example, the OAuth token exchange and repository API requests may need to pass through a same-origin proxy on the deployed site to avoid CORS restrictions, while OAuth authorization remains a top-level navigation to the Git provider's canonical origin so that it continues to serve its own login and consent interface.

This PR adds three optional `cms` configuration fields so each endpoint can be configured independently. The current single-origin derivation remains the default.

## What changed

Three optional fields are added to the `cms` configuration:

| Field               | Overrides               | Default when omitted or empty                                         |
| ------------------- | ----------------------- | --------------------------------------------------------------------- |
| `authorization_url` | OAuth authorization URL | `<repo-origin>` plus the provider authorization path                  |
| `access_token_url`  | OAuth token URL         | `<repo-origin>` plus the provider token path                          |
| `api_base_url`      | Provider API base URL   | `<repo-origin>/api/v1` for Gitea or `<repo-origin>/api/v4` for GitLab |

`access_token_url` is used for both the initial authorization-code exchange and token refresh.

Implementation changes:

* `readers/site_config.go` adds the three optional JSON configuration fields.
* `cmd/build/data_source.go` passes the values through to the generated `env.cms`.
* `defaults/core/cms/auth.js` applies the authorization and access-token overrides, with the existing repository-derived URLs as fallbacks.
* `defaults/core/cms/providers/gitea.js` and `gitlab.js` apply the optional API base override.
* `defaults/core/cms/ENDPOINT-OVERRIDES.md` documents the fields and split-origin use case.

## Example

```json
{
  "cms": {
    "provider": "gitea",
    "repo": "https://git.example.com/owner/repository",
    "branch": "main",
    "redirect_url": "https://site.example.com",
    "app_id": "public-oauth-client-id",
    "authorization_url": "https://git.example.com/login/oauth/authorize",
    "access_token_url": "https://site.example.com/_cms/git/login/oauth/access_token",
    "api_base_url": "https://site.example.com/_cms/git/api/v1"
  }
}
```
In this example, the site's hosting layer routes `site.example.com/_cms/git/*` to the Git provider. The proxy remains outside Plenti; Plenti only needs to know which endpoint to call.

Deployments that do not need independent endpoints can omit the three fields and retain the existing behaviour.

## Backward compatibility

* All three fields are optional.
* When an override is omitted or empty, Plenti uses the same provider-specific endpoint derivation as before.
* `repo` remains the source of provider and repository identity. The new fields affect request routing only.
* The existing public-client PKCE flow is unchanged.
* No client secret is introduced.
* Existing `state`, `code_challenge`, `code_challenge_method=S256`, and `code_verifier` handling is unchanged.
* GitLab and Gitea default endpoint resolution is preserved.
* The `forgejo` provider value continues to use the Gitea endpoint-resolution path.

## Validation

The repository test was validated using the existing build tooling and manual endpoint-resolution checks.

Completed checks:

* `go build ./...`
* `go vet ./readers/... ./cmd/build/...`
* built a throwaway Plenti site using the binary from this branch;
* inspected generated `env.cms` output with no overrides;
* inspected generated `env.cms` output with all overrides;
* confirmed omitted fields emit empty strings and fall back to the existing provider-derived URLs;
* confirmed configured values flow through to generated `env.cms`;
* confirmed `access_token_url` is used for both code exchange and token refresh;
* confirmed independent and partial override behaviour;
* confirmed GitLab defaults, Gitea defaults, and the Forgejo-to-Gitea alias behaviour remain unchanged.

The configuration and endpoint-routing behaviour have been verified locally. A full deployment-specific integration test against a live Gitea instance and reverse proxy has not yet been performed.

## Notes

The proposed field names are open to your preference, and I'm happy to adjust the configuration shape or documentation during review. 
Regards,
Ben